### PR TITLE
Implement horizontal viewport scrolling

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -74,10 +74,12 @@ impl EditorPane {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
-        self.viewport.height = inner.height as usize;
-        self.viewport.ensure_cursor_visible(self.cursor.line);
-
         let gutter_w = self.gutter_width();
+
+        self.viewport.height = inner.height as usize;
+        self.viewport.width = (inner.width as usize).saturating_sub(gutter_w);
+        self.viewport.ensure_cursor_visible(self.cursor.line);
+        self.viewport.ensure_cursor_col_visible(self.cursor.col);
 
         let mut lines: Vec<Line> = Vec::with_capacity(inner.height as usize);
         for row in 0..inner.height as usize {
@@ -99,7 +101,7 @@ impl EditorPane {
                 Style::default().fg(theme.gutter_fg)
             };
 
-            let content = self
+            let full_content = self
                 .buffer
                 .line(line_idx)
                 .map(|l| {
@@ -108,13 +110,16 @@ impl EditorPane {
                 })
                 .unwrap_or_default();
 
+            let col_offset = self.viewport.col_offset;
+            let vis_width = self.viewport.width;
+
             let line_byte_start = self.buffer.rope.line_to_byte(line_idx);
             let line_byte_end = if line_idx + 1 < self.buffer.line_count() {
                 self.buffer.rope.line_to_byte(line_idx + 1)
             } else {
                 self.buffer.rope.len_bytes()
             };
-            let display_len = content.len();
+            let full_len = full_content.len();
 
             let hl_spans = self.highlighter.highlight_line(
                 &self.buffer.rope.to_string(),
@@ -138,43 +143,71 @@ impl EditorPane {
 
             let default_fg = if is_cursor_line { theme.fg } else { theme.fg };
 
+            // Slice content to the visible horizontal window
+            let slice_start = col_offset.min(full_len);
+            let slice_end = (col_offset + vis_width).min(full_len);
+
             if hl_spans.is_empty() {
+                let visible = &full_content[slice_start..slice_end];
                 let style = match line_bg {
                     Some(bg) => Style::default().fg(default_fg).bg(bg),
                     None => Style::default().fg(default_fg),
                 };
-                result_spans.push(Span::styled(content, style));
+                result_spans.push(Span::styled(visible.to_string(), style));
             } else {
                 let mut pos = 0;
                 for (start, end, group) in &hl_spans {
-                    let start = (*start).min(display_len);
-                    let end = (*end).min(display_len);
+                    let start = (*start).min(full_len);
+                    let end = (*end).min(full_len);
+
+                    // Handle gap before this span
                     if start > pos {
-                        let gap = &content[pos..start];
+                        let gap_vis_start = pos.max(slice_start);
+                        let gap_vis_end = start.min(slice_end);
+                        if gap_vis_start < gap_vis_end {
+                            let style = match line_bg {
+                                Some(bg) => Style::default().fg(default_fg).bg(bg),
+                                None => Style::default().fg(default_fg),
+                            };
+                            result_spans.push(Span::styled(
+                                full_content[gap_vis_start..gap_vis_end].to_string(),
+                                style,
+                            ));
+                        }
+                    }
+
+                    // Handle the highlighted span
+                    if start < end {
+                        let span_vis_start = start.max(slice_start);
+                        let span_vis_end = end.min(slice_end);
+                        if span_vis_start < span_vis_end {
+                            let color = theme.color_for_group(*group);
+                            let style = match line_bg {
+                                Some(bg) => Style::default().fg(color).bg(bg),
+                                None => Style::default().fg(color),
+                            };
+                            result_spans.push(Span::styled(
+                                full_content[span_vis_start..span_vis_end].to_string(),
+                                style,
+                            ));
+                        }
+                    }
+                    pos = end;
+                }
+                // Handle remaining text after last highlight span
+                if pos < full_len {
+                    let rest_vis_start = pos.max(slice_start);
+                    let rest_vis_end = full_len.min(slice_end);
+                    if rest_vis_start < rest_vis_end {
                         let style = match line_bg {
                             Some(bg) => Style::default().fg(default_fg).bg(bg),
                             None => Style::default().fg(default_fg),
                         };
-                        result_spans.push(Span::styled(gap.to_string(), style));
+                        result_spans.push(Span::styled(
+                            full_content[rest_vis_start..rest_vis_end].to_string(),
+                            style,
+                        ));
                     }
-                    if start < end {
-                        let text = &content[start..end];
-                        let color = theme.color_for_group(*group);
-                        let style = match line_bg {
-                            Some(bg) => Style::default().fg(color).bg(bg),
-                            None => Style::default().fg(color),
-                        };
-                        result_spans.push(Span::styled(text.to_string(), style));
-                    }
-                    pos = end;
-                }
-                if pos < display_len {
-                    let rest = &content[pos..];
-                    let style = match line_bg {
-                        Some(bg) => Style::default().fg(default_fg).bg(bg),
-                        None => Style::default().fg(default_fg),
-                    };
-                    result_spans.push(Span::styled(rest.to_string(), style));
                 }
             }
 
@@ -185,7 +218,8 @@ impl EditorPane {
         frame.render_widget(paragraph, inner);
 
         if focused {
-            let cursor_x = inner.x + gutter_w as u16 + self.cursor.col as u16;
+            let col_offset = self.viewport.col_offset;
+            let cursor_x = inner.x + gutter_w as u16 + (self.cursor.col.saturating_sub(col_offset)) as u16;
             let cursor_y = inner.y + (self.cursor.line - self.viewport.top_line) as u16;
             if cursor_x < inner.x + inner.width && cursor_y < inner.y + inner.height {
                 frame.set_cursor_position((cursor_x, cursor_y));

--- a/src/editor/viewport.rs
+++ b/src/editor/viewport.rs
@@ -1,13 +1,19 @@
 pub struct Viewport {
     pub top_line: usize,
     pub height: usize,
+    pub col_offset: usize,
+    pub width: usize,
 }
+
+const H_SCROLL_MARGIN: usize = 6;
 
 impl Viewport {
     pub fn new() -> Self {
         Self {
             top_line: 0,
             height: 0,
+            col_offset: 0,
+            width: 0,
         }
     }
 
@@ -16,6 +22,20 @@ impl Viewport {
             self.top_line = cursor_line;
         } else if cursor_line >= self.top_line + self.height {
             self.top_line = cursor_line - self.height + 1;
+        }
+    }
+
+    pub fn ensure_cursor_col_visible(&mut self, cursor_col: usize) {
+        if self.width == 0 {
+            return;
+        }
+
+        let margin = H_SCROLL_MARGIN.min(self.width / 2);
+
+        if cursor_col < self.col_offset.saturating_add(margin) {
+            self.col_offset = cursor_col.saturating_sub(margin);
+        } else if cursor_col >= self.col_offset + self.width.saturating_sub(margin) {
+            self.col_offset = cursor_col.saturating_sub(self.width.saturating_sub(margin + 1));
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `col_offset` and `width` fields to `Viewport` struct for horizontal scroll state
- Implements `ensure_cursor_col_visible()` with Vim-style scroll margin (6 cols, clamped to half-width for narrow terminals)
- Slices line content and syntax highlight spans to the visible horizontal window during rendering
- Updates cursor x calculation to account for `col_offset`

Closes #2

## Test plan
- [ ] `cargo build && cargo test` pass
- [ ] Open a file with long lines, move cursor right past screen edge -- viewport scrolls right
- [ ] Move cursor back left -- viewport scrolls back
- [ ] `$` (end of line) and `0` (start of line) trigger correct scrolling
- [ ] Narrow terminal widths handled without panic

## IT Department Governance
- Standards Keeper: PASS (5/5)
- Lead Architect: Approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)