### PR TITLE
Add supported languages section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ show_line_numbers = true
 tab_size = 4
 ```
 
+## Supported Languages
+
+| Language | Extensions |
+|----------|------------|
+| Rust | `.rs` |
+| Python | `.py`, `.pyi` |
+| JavaScript | `.js`, `.jsx`, `.mjs`, `.cjs` |
+| JSON | `.json`, `.jsonc` |
+| TOML | `.toml` |
+| Markdown | `.md`, `.markdown` |
+
 ## Architecture
 
 Built with the same stack as the Helix editor:


### PR DESCRIPTION
## Summary
- Adds a dedicated "Supported Languages" section to README with a table listing all 6 tree-sitter languages and their file extensions
- Placed before the Architecture section for logical flow

Closes #4

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm extensions match `src/syntax/languages.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)